### PR TITLE
Switch to using libusb ruby gem in favour of ruby-usb

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,8 @@
+source 'https://rubygems.org'
+
+gem "libusb"
+
+group :development do
+  gem "ruby-debug-ide"
+  gem "debase"
+end

--- a/INSTALL
+++ b/INSTALL
@@ -1,6 +1,6 @@
-Currently the combustd library and applications need a very generic set of dependencies. The core library only needs Ruby, libusb and ruby-usb available on your system. This makes it possible to run basically everywhere. Applications might have their own dependencies, for more information look for a INSTALL file in it's respective directory.
+Currently the combustd library and applications need a very generic set of dependencies. The core library only needs Ruby, libusb and the libusb gem available on your system. This makes it possible to run basically everywhere. Applications might have their own dependencies, for more information look for a INSTALL file in it's respective directory.
 
 Installing these dependencies might be as trivial as using your package manager (apt, aptitude, yum, ports, fink, etc.), if these fail or are missing request them at your maintainer or choose to install them from source.
 
 libusb: http://www.libusb.org/
-Ruby-usb: http://www.a-k-r.org/ruby-usb/
+libusb gem: https://github.com/larskanis/libusb

--- a/libcombustd/libcombustd.rb
+++ b/libcombustd/libcombustd.rb
@@ -2,7 +2,7 @@ REQUIREMENTPATH = File.dirname(__FILE__)
 
 # ruby-usb; http://www.a-k-r.org/ruby-usb/
 # a ruby wrapper around libusb, needs to be compiled from source and gem installed.
-require 'usb'
+require "libusb"
 
 # Classes for definitions
 require REQUIREMENTPATH + '/data/protocoldefinitions'


### PR DESCRIPTION
Hi there!

I know this is an ancient repository, but I had a use for it!
Are you interested in pull requests for this project? 
If not, then I just want to say: thanks for your work! 
If yes…

I'm a fan of the amBX speakers, a Mac user (where no drivers for ambx exist), and a ruby programmer and recently got a working set of speakers again. I got the lights working, thanks to your work, but I did have to move over to the `libusb` gem instead of `ruby-usb`.

This is what I had to do to get it working again. My plans are to add multi-device support (I have 2 working sets at my disposal), to eventually develop a plugin for homebridge.

With kind regards,
Etienne